### PR TITLE
Add option to strip unused components

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ removing all others and also removing some DTOs:
 ```bash
 openapi-trimmer -i openapi.yaml \
   -p /v1/quotes,/v1/users \
-  -ec CompanyConfigDto,UpdateCompanyConfigDto
+  -ec CompanyConfigDto,UpdateCompanyConfigDto \
+  -sc
 ```
 
 The output will be stored in `openapi-trimmer.yaml`
+
+Pass `-sc` to strip any components not referenced by the selected paths.
 
 At the end validate with:
 


### PR DESCRIPTION
## Summary
- add `-sc/--strip-components` flag to prune unreferenced components in trimmed specs
- strip components recursively so nested references are retained
- document new `-sc` option in README

## Testing
- `pytest`
- ⚠️ `pip install pyyaml` (failed: Tunnel connection failed: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_b_68b034fe658c832e982a6c497776fff0