### PR TITLE
feat: expose trimming logic for programmatic use

### DIFF
--- a/openapi_trimmer/__init__.py
+++ b/openapi_trimmer/__init__.py
@@ -1,1 +1,5 @@
 __author__ = 'Ivan Dachev'
+
+from .main import trim_openapi
+
+__all__ = ["trim_openapi"]

--- a/openapi_trimmer/main.py
+++ b/openapi_trimmer/main.py
@@ -199,8 +199,9 @@ def offer_validation_execute(output_path):
     print(f"\nswagger-cli validate {output_path}\n")
 
 
-def trim_openapi(input_path, prefixes, output_path=None, *,
+def trim_openapi(input_path, prefixes, output_path=None,
                  exclude_components=None, strip_components=False):
+    """Returns written output_path"""
     data, has_yaml_doc_separator = read_yaml(input_path)
     data = trim_yaml(prefixes, exclude_components, strip_components, data)
     output_path = build_output_path(input_path, output_path)

--- a/openapi_trimmer/main.py
+++ b/openapi_trimmer/main.py
@@ -199,23 +199,25 @@ def offer_validation_execute(output_path):
     print(f"\nswagger-cli validate {output_path}\n")
 
 
+def trim_openapi(input_path, prefixes, output_path=None, *,
+                 exclude_components=None, strip_components=False):
+    data, has_yaml_doc_separator = read_yaml(input_path)
+    data = trim_yaml(prefixes, exclude_components, strip_components, data)
+    output_path = build_output_path(input_path, output_path)
+    write_trimmed_yaml(output_path, data, has_yaml_doc_separator)
+    return output_path
+
+
 def main():
     args = parse_args()
 
-    input_path = args.input
-    output_path = args.output
-    prefixes = args.prefixes
-    exclude_components = args.exclude_components
-    strip_components = args.strip_components
-
-    data, has_yaml_doc_separator = read_yaml(input_path)
-
-    data = trim_yaml(prefixes, exclude_components, strip_components, data)
-
-    output_path = build_output_path(input_path, output_path)
-
-    write_trimmed_yaml(output_path, data, has_yaml_doc_separator)
-
+    output_path = trim_openapi(
+        args.input,
+        args.prefixes,
+        output_path=args.output,
+        exclude_components=args.exclude_components,
+        strip_components=args.strip_components,
+    )
     offer_validation_execute(output_path)
 
 


### PR DESCRIPTION
## Summary
- allow trimming logic to be invoked from Python via `trim_openapi`
- retain CLI behavior by calling the new function

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b03a2e5a8c832e924376b080fc4747